### PR TITLE
Prepare dafr for CRAN submission

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@
 ^conda-recipe$
 ^\.a5c$
 ^\.claude$
+^environment\.yml$
+^cran-comments\.md$

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -1,0 +1,95 @@
+# R-hub's generic GitHub Actions workflow file. It's canonical location is at
+# https://github.com/r-hub/actions/blob/v1/workflows/rhub.yaml
+# You can update this file to a newer version using the rhub2 package:
+#
+# rhub::rhub_setup()
+#
+# It is unlikely that you need to modify this file manually.
+
+name: R-hub
+run-name: "${{ github.event.inputs.id }}: ${{ github.event.inputs.name || format('Manually run by {0}', github.triggering_actor) }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      config:
+        description: 'A comma separated list of R-hub platforms to use.'
+        type: string
+        default: 'linux,windows,macos'
+      name:
+        description: 'Run name. You can leave this empty now.'
+        type: string
+      id:
+        description: 'Unique ID. You can leave this empty now.'
+        type: string
+
+jobs:
+
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      containers: ${{ steps.rhub-setup.outputs.containers }}
+      platforms: ${{ steps.rhub-setup.outputs.platforms }}
+
+    steps:
+    # NO NEED TO CHECKOUT HERE
+    - uses: r-hub/actions/setup@v1
+      with:
+        config: ${{ github.event.inputs.config }}
+      id: rhub-setup
+
+  linux-containers:
+    needs: setup
+    if: ${{ needs.setup.outputs.containers != '[]' }}
+    runs-on: ubuntu-latest
+    name: ${{ matrix.config.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.setup.outputs.containers) }}
+    container:
+      image: ${{ matrix.config.container }}
+
+    steps:
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/platform-info@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/setup-deps@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/run-check@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+
+  other-platforms:
+    needs: setup
+    if: ${{ needs.setup.outputs.platforms != '[]' }}
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.setup.outputs.platforms) }}
+
+    steps:
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/setup-r@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}
+      - uses: r-hub/actions/platform-info@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/setup-deps@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}
+      - uses: r-hub/actions/run-check@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,8 @@ URL: https://tanaylab.github.io/dafr/, https://github.com/tanaylab/dafr
 BugReports: https://github.com/tanaylab/dafr/issues
 Depends: 
     R (>= 4.1.0)
+SystemRequirements: Julia (>= 1.10), DataAxesFormats.jl, TanayLabUtilities.jl,
+    Muon.jl, NamedArrays.jl
 Imports: 
     cli,
     JuliaCall,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,13 +5,12 @@
 ## R CMD check results
 
 - `R CMD build .`
-- `R CMD check --as-cran --no-manual dafr_0.0.3.tar.gz`
+- `_R_CHECK_SYSTEM_CLOCK_=FALSE R CMD check --as-cran --no-manual dafr_0.0.3.tar.gz`
 
-Result: 0 errors | 0 warnings | 2 notes
+Result: 0 errors | 0 warnings | 1 note
 
 Notes observed:
 - New submission.
-- unable to verify current time (environment-specific).
 
 ## Julia dependency notes
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,21 @@
+## Test environments
+
+- Local Linux (AlmaLinux 8.10), R 4.4.1
+
+## R CMD check results
+
+- `R CMD build .`
+- `R CMD check --as-cran --no-manual dafr_0.0.3.tar.gz`
+
+Result: 0 errors | 0 warnings | 2 notes
+
+Notes observed:
+- New submission.
+- unable to verify current time (environment-specific).
+
+## Julia dependency notes
+
+`dafr` interfaces with Julia via `JuliaCall`. Julia runtime and Julia packages are declared in
+`SystemRequirements` and are only initialized when users call `setup_daf()`.
+
+The test suite is gated to avoid Julia-dependent checks on CRAN environments.


### PR DESCRIPTION
## Summary
- add explicit Julia-related SystemRequirements in DESCRIPTION
- ignore non-package top-level files in .Rbuildignore
- add cran-comments.md draft for submission

## Validation
- R CMD build .
- R CMD check --as-cran --no-manual dafr_0.0.3.tar.gz (0 errors, 0 warnings; notes only for new submission/time verification in local env)

## Notes
- Full local --as-cran fails only because pdflatex is unavailable in this environment.
