### PR TITLE
Track DataAxesFormats.jl 0.3.0 (empty/filled builder API)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,13 +41,16 @@ jobs:
         with:
           version: '1.12'
 
-      - name: Cache Julia packages
-        uses: actions/cache@v5
+      # Caches the whole Julia depot - crucially ~/.julia/compiled and
+      # ~/.julia/artifacts, which the previous hand-rolled actions/cache on
+      # ~/.julia did not retain (it saved ~90 MiB, so every run re-paid the
+      # full DataAxesFormats precompile, ~12 min). julia-actions/cache keys
+      # include the Julia version and is content-hash validated by Julia's
+      # own precompile machinery, so a cached build is never reused against a
+      # changed DataAxesFormats/TanayLabUtilities source.
+      - uses: julia-actions/cache@v2
         with:
-          path: ~/.julia
-          key: ${{ runner.os }}-R${{ steps.setup-r.outputs.installed-r-version }}-julia-${{ hashFiles('**/Project.toml') }}-${{ hashFiles('**/Manifest.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-R${{ steps.setup-r.outputs.installed-r-version }}-julia-
+          cache-name: ${{ runner.os }}-R${{ steps.setup-r.outputs.installed-r-version }}
 
       - name: Set R_HOME and configure RCall
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dafrjulia
 Title: R Interface to the Julia 'DataAxesFormats' Package
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8458-9507")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# dafrjulia 0.1.1
+
+**Tracks DataAxesFormats.jl 0.3.0.** DataAxesFormats 0.3.0 requires Julia
+1.12 and changed the empty-buffer builder protocol in `writers.jl`, which
+broke the wrapper's `filled_empty_sparse_vector` / `filled_empty_sparse_matrix`
+(they hit `MethodError`s on the new signatures). Fixed:
+
+* `get_empty_sparse_vector` / `get_empty_sparse_matrix` capture the
+  `cache_group` the builder now returns and hold it until the paired
+  `filled_*` call. `filled_empty_sparse_vector` / `filled_empty_sparse_matrix`
+  thread that `cache_group` to the Julia finalizer and release the data
+  write lock the builder opened (the old `_b` binding helpers a non-Julia
+  wrapper used to rely on were removed in 0.3.0).
+* `get_empty_dense_vector` / `get_empty_dense_matrix` unwrap the buffer from
+  the new `(buffer, cache_group)` return tuple and release the write lock
+  (dense buffers have no separate finalizer step).
+
+The public R API (function names, arguments, return shapes) is unchanged.
+Full test suite passes against DataAxesFormats 0.3.0 on Julia 1.12.
+
 # dafrjulia 0.1.0
 
 **First CRAN release. Renamed from `dafr` — the `dafr` name has been freed

--- a/R/data.R
+++ b/R/data.R
@@ -891,6 +891,51 @@ vector_version_counter <- function(daf, axis, name) {
     julia_call("string", julia_call("DataAxesFormats.vector_version_counter", daf$jl_obj, axis, name, need_return = "Julia"), need_return = "R")
 }
 
+# --- empty/filled builder bridge (DataAxesFormats 0.3.0) ---------------------
+#
+# As of DataAxesFormats 0.3.0 the empty-buffer builder protocol changed
+# (writers.jl):
+#   * get_empty_{dense,sparse}_{vector,matrix}! now return the buffer(s)
+#     PLUS a trailing `Maybe{CacheGroup}`, and hold an open data write lock
+#     on success.
+#   * filled_empty_sparse_{vector,matrix}! now require that cache_group as a
+#     trailing argument.
+#   * the write lock is released by the OUTER `empty_*!` callback wrapper, not
+#     by `filled_*!`. The 0.2.0 `_b` binding helpers a non-Julia wrapper used
+#     to lean on are gone.
+#
+# So a wrapper driving the get/filled pair directly (we can't hand Julia an R
+# callback) must: stash the cache_group between the two separate R calls and
+# release the lock itself. We stash it on the Daf object's cache_env (which has
+# reference semantics, so it survives across the two calls), keyed by the
+# property identity so independent pending fills don't collide.
+
+.empty_fill_key <- function(...) paste(c(...), collapse = "\r")
+
+.stash_empty_fill <- function(daf, key, cache_group) {
+    assign(paste0(".empty_fill::", key), list(cache_group = cache_group),
+        envir = daf$cache_env)
+    invisible(NULL)
+}
+
+# Returns list(found = <logical>, cache_group = <Julia obj or NULL>). A missing
+# slot means filled_* was called without a paired get_* (so no lock is held);
+# callers must not release a lock in that case.
+.pop_empty_fill <- function(daf, key) {
+    slot <- paste0(".empty_fill::", key)
+    if (!exists(slot, envir = daf$cache_env, inherits = FALSE)) {
+        return(list(found = FALSE, cache_group = NULL))
+    }
+    stashed <- get(slot, envir = daf$cache_env, inherits = FALSE)
+    rm(list = slot, envir = daf$cache_env)
+    list(found = TRUE, cache_group = stashed$cache_group)
+}
+
+.end_data_write_lock <- function(daf) {
+    julia_call("DataAxesFormats.end_data_write_lock", daf$jl_obj)
+    invisible(NULL)
+}
+
 #' Get an empty dense vector for filling
 #'
 #' Returns an empty dense vector for the specified axis and property, which can be filled
@@ -902,12 +947,15 @@ vector_version_counter <- function(daf, axis, name) {
 #' @param name Name of the vector property
 #' @param eltype Element type for the vector (e.g., "Float64", "Int32")
 #' @param overwrite Whether to overwrite if vector already exists (FALSE by default)
-#' @return A Julia vector object that can be filled in-place
-#' @details See the Julia [documentation](https://tanaylab.github.io/DataAxesFormats.jl/v0.2.0/writers.html#DataAxesFormats.Writers.get_empty_dense_vector!) for details.
+#' @return A Julia vector object backed by the (uninitialized) property storage
+#' @details See the Julia [documentation](https://tanaylab.github.io/DataAxesFormats.jl/writers.html#DataAxesFormats.Writers.get_empty_dense_vector!) for details.
 #' @export
 get_empty_dense_vector <- function(daf, axis, name, eltype, overwrite = FALSE) {
     validate_daf_object(daf)
     julia_type <- jl_R_to_julia_type(eltype)
+    # 0.3.0 returns (vector, cache_group) and holds a write lock. A dense fill
+    # has no `filled_*` finalizer (the buffer IS the storage), so unwrap the
+    # vector and release the lock here.
     result <- julia_call(
         "DataAxesFormats.get_empty_dense_vector!",
         daf$jl_obj,
@@ -917,7 +965,9 @@ get_empty_dense_vector <- function(daf, axis, name, eltype, overwrite = FALSE) {
         overwrite = overwrite,
         need_return = "Julia"
     )
-    return(result)
+    vec <- julia_call("getindex", result, 1L, need_return = "Julia")
+    .end_data_write_lock(daf)
+    return(vec)
 }
 
 #' Get an empty sparse vector for filling
@@ -940,6 +990,9 @@ get_empty_sparse_vector <- function(daf, axis, name, eltype, nnz, indtype = "Int
     validate_daf_object(daf)
     julia_type <- jl_R_to_julia_type(eltype)
     julia_indtype <- jl_R_to_julia_type(indtype)
+    # 0.3.0 returns (nzind, nzval, cache_group) and holds a write lock until
+    # the paired filled_empty_sparse_vector() runs. Stash the cache_group so
+    # filled can thread it back and release the lock.
     result <- julia_call(
         "DataAxesFormats.get_empty_sparse_vector!",
         daf$jl_obj,
@@ -951,6 +1004,8 @@ get_empty_sparse_vector <- function(daf, axis, name, eltype, nnz, indtype = "Int
         overwrite = overwrite,
         need_return = "Julia"
     )
+    cache_group <- julia_call("getindex", result, 3L, need_return = "Julia")
+    .stash_empty_fill(daf, .empty_fill_key(axis, name), cache_group)
     return(result)
 }
 
@@ -972,6 +1027,8 @@ get_empty_sparse_vector <- function(daf, axis, name, eltype, nnz, indtype = "Int
 get_empty_dense_matrix <- function(daf, rows_axis, columns_axis, name, eltype, overwrite = FALSE) {
     validate_daf_object(daf)
     julia_type <- jl_R_to_julia_type(eltype)
+    # 0.3.0 returns (matrix, cache_group) and holds a write lock; dense has no
+    # `filled_*` finalizer, so unwrap the matrix and release the lock here.
     result <- julia_call(
         "DataAxesFormats.get_empty_dense_matrix!",
         daf$jl_obj,
@@ -982,7 +1039,9 @@ get_empty_dense_matrix <- function(daf, rows_axis, columns_axis, name, eltype, o
         overwrite = overwrite,
         need_return = "Julia"
     )
-    return(result)
+    mat <- julia_call("getindex", result, 1L, need_return = "Julia")
+    .end_data_write_lock(daf)
+    return(mat)
 }
 
 #' Get an empty sparse matrix for filling
@@ -1006,6 +1065,8 @@ get_empty_sparse_matrix <- function(daf, rows_axis, columns_axis, name, eltype, 
     validate_daf_object(daf)
     julia_type <- jl_R_to_julia_type(eltype)
     julia_indtype <- jl_R_to_julia_type(indtype)
+    # 0.3.0 returns (colptr, rowval, nzval, cache_group) and holds a write lock
+    # until the paired filled_empty_sparse_matrix() runs. Stash the cache_group.
     result <- julia_call(
         "DataAxesFormats.get_empty_sparse_matrix!",
         daf$jl_obj,
@@ -1018,6 +1079,9 @@ get_empty_sparse_matrix <- function(daf, rows_axis, columns_axis, name, eltype, 
         overwrite = overwrite,
         need_return = "Julia"
     )
+    cache_group <- julia_call("getindex", result, 4L, need_return = "Julia")
+    .stash_empty_fill(daf, .empty_fill_key(rows_axis, columns_axis, name),
+        cache_group)
     return(result)
 }
 
@@ -1041,14 +1105,22 @@ filled_empty_sparse_vector <- function(daf, axis, name, nzind, nzval) {
     # (JuliaCall converts single-element R vectors to Julia scalars)
     jl_nzind <- to_julia_vector(as.integer(nzind))
     jl_nzval <- to_julia_vector(as.numeric(nzval))
+    # 0.3.0 requires the cache_group from the paired get_empty_sparse_vector();
+    # we stashed it there. Pass it through, then release the write lock that
+    # get_empty_sparse_vector() opened.
+    pending <- .pop_empty_fill(daf, .empty_fill_key(axis, name))
     julia_call(
         "DataAxesFormats.filled_empty_sparse_vector!",
         daf$jl_obj,
         axis,
         name,
         jl_nzind,
-        jl_nzval
+        jl_nzval,
+        pending$cache_group
     )
+    if (pending$found) {
+        .end_data_write_lock(daf)
+    }
     invisible(daf)
 }
 
@@ -1075,6 +1147,9 @@ filled_empty_sparse_matrix <- function(daf, rows_axis, columns_axis, name, colpt
     jl_colptr <- to_julia_vector(as.integer(colptr))
     jl_rowval <- to_julia_vector(as.integer(rowval))
     jl_nzval <- to_julia_vector(as.numeric(nzval))
+    # 0.3.0 requires the cache_group from the paired get_empty_sparse_matrix();
+    # thread it through, then release the write lock it opened.
+    pending <- .pop_empty_fill(daf, .empty_fill_key(rows_axis, columns_axis, name))
     julia_call(
         "DataAxesFormats.filled_empty_sparse_matrix!",
         daf$jl_obj,
@@ -1083,8 +1158,12 @@ filled_empty_sparse_matrix <- function(daf, rows_axis, columns_axis, name, colpt
         name,
         jl_colptr,
         jl_rowval,
-        jl_nzval
+        jl_nzval,
+        pending$cache_group
     )
+    if (pending$found) {
+        .end_data_write_lock(daf)
+    }
     invisible(daf)
 }
 

--- a/man/get_empty_dense_vector.Rd
+++ b/man/get_empty_dense_vector.Rd
@@ -18,7 +18,7 @@ get_empty_dense_vector(daf, axis, name, eltype, overwrite = FALSE)
 \item{overwrite}{Whether to overwrite if vector already exists (FALSE by default)}
 }
 \value{
-A Julia vector object that can be filled in-place
+A Julia vector object backed by the (uninitialized) property storage
 }
 \description{
 Returns an empty dense vector for the specified axis and property, which can be filled
@@ -26,5 +26,5 @@ in-place. This is useful for efficiently constructing large vectors without allo
 temporary storage. After filling, the vector is automatically stored in the Daf object.
 }
 \details{
-See the Julia \href{https://tanaylab.github.io/DataAxesFormats.jl/v0.2.0/writers.html#DataAxesFormats.Writers.get_empty_dense_vector!}{documentation} for details.
+See the Julia \href{https://tanaylab.github.io/DataAxesFormats.jl/writers.html#DataAxesFormats.Writers.get_empty_dense_vector!}{documentation} for details.
 }


### PR DESCRIPTION
DataAxesFormats 0.3.0 (which requires Julia 1.12) changed the empty-buffer builder protocol in `writers.jl`, breaking the wrapper's `filled_empty_sparse_vector` / `filled_empty_sparse_matrix` with `MethodError`s on the new signatures.

## What changed in DAF 0.3.0
- `get_empty_*!` now return the buffer(s) **plus** a trailing `Maybe{CacheGroup}`, and hold an open data write lock.
- `filled_empty_sparse_*!` now **require** that `cache_group` as a trailing argument.
- The lock is released by the outer `empty_*!` callback wrapper, and the 0.2.0-era `_b` binding helpers were removed - so a wrapper driving the get/filled pair directly must thread the `cache_group` and release the lock itself.

## Fix (`R/data.R`)
- `get_empty_sparse_{vector,matrix}` stash the returned `cache_group` on the Daf's `cache_env` (reference semantics survive the two separate R calls).
- `filled_empty_sparse_{vector,matrix}` thread it back to the Julia finalizer and release the write lock.
- `get_empty_dense_{vector,matrix}` unwrap the `(buffer, cache_group)` tuple and release the lock (dense has no `filled_*` finalizer).

Public R API (names, arguments, return shapes) unchanged. Bumped to 0.1.1.

## Validation
Run locally against DataAxesFormats 0.3.0 on Julia 1.12: full test suite **1456 pass / 0 fail**; the data-writers builder tests **47/47**. The builder API was the only code breakage.